### PR TITLE
cassandra-stress pom fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>me.prettyprint</groupId>
 			<artifactId>hector-core</artifactId>
-			<version>0.8.0-3-SNAPSHOT</version>
+			<version>0.8.0-3</version>
 		</dependency>
 		<dependency>
             <groupId>org.apache.cassandra</groupId>


### PR DESCRIPTION
Removed SNAPSHOT from hector-core maven dependency version. This makes it work correctly with current maven repos and appears to build and run correctly. Please pull unless there is some need for the "SNAPSHOT" version that I am unaware of.
